### PR TITLE
Add custom rendering experience for MediaStreamControl (#72)

### DIFF
--- a/docs/src/components/App.tsx
+++ b/docs/src/components/App.tsx
@@ -6,7 +6,7 @@ import {
     ConferenceStream,
     Stream,
     MediaStreamControl,
-    IMediaStreamControlHandle,
+    IMediaStreamControlProps,
 } from 'react-conf-webrtc';
 import CustomMediaStreamControl from './CustomMediaStreamControl'
 
@@ -42,8 +42,8 @@ export class App extends React.Component<{}, {}> {
         )
     }
 
-    private renderMediaStreamControl(handle: IMediaStreamControlHandle) {
-        return <CustomMediaStreamControl handle={handle} />
+    private renderMediaStreamControl(props: IMediaStreamControlProps) {
+        return <CustomMediaStreamControl {...props} />
     }
 
     private renderConferenceRoom(localStream: ConferenceStream | undefined, remoteStreams: ConferenceStream[]): JSX.Element | null | false {

--- a/docs/src/components/App.tsx
+++ b/docs/src/components/App.tsx
@@ -1,6 +1,14 @@
 import 'webrtc-adapter';
 import * as React from 'react';
-import { Conference, Connect, ConferenceStream, Stream, MediaStreamControl } from 'react-conf-webrtc';
+import {
+    Conference,
+    Connect,
+    ConferenceStream,
+    Stream,
+    MediaStreamControl,
+    IMediaStreamControlHandle,
+} from 'react-conf-webrtc';
+import CustomMediaStreamControl from './CustomMediaStreamControl'
 
 const config: RTCConfiguration = {
     'iceServers': [
@@ -34,6 +42,10 @@ export class App extends React.Component<{}, {}> {
         )
     }
 
+    private renderMediaStreamControl(handle: IMediaStreamControlHandle) {
+        return <CustomMediaStreamControl handle={handle} />
+    }
+
     private renderConferenceRoom(localStream: ConferenceStream | undefined, remoteStreams: ConferenceStream[]): JSX.Element | null | false {
         return (
             <div className='docs-conf'>
@@ -49,7 +61,10 @@ export class App extends React.Component<{}, {}> {
 
                 {localStream ? (
                     <div className='docs-conf-stream-controls'>
-                        <MediaStreamControl stream={localStream.stream} />
+                        <MediaStreamControl
+                            stream={localStream.stream}
+                            render={this.renderMediaStreamControl}
+                        />
                     </div>
                 ) : null}
             </div>

--- a/docs/src/components/App.tsx
+++ b/docs/src/components/App.tsx
@@ -6,7 +6,7 @@ import {
     ConferenceStream,
     Stream,
     MediaStreamControl,
-    IMediaStreamControlProps,
+    IMediaStreamControlRendererProps,
 } from 'react-conf-webrtc';
 import CustomMediaStreamControl from './CustomMediaStreamControl'
 
@@ -42,7 +42,7 @@ export class App extends React.Component<{}, {}> {
         )
     }
 
-    private renderMediaStreamControl(props: IMediaStreamControlProps) {
+    private renderMediaStreamControl(props: IMediaStreamControlRendererProps) {
         return <CustomMediaStreamControl {...props} />
     }
 

--- a/docs/src/components/CustomMediaStreamControl.tsx
+++ b/docs/src/components/CustomMediaStreamControl.tsx
@@ -1,32 +1,20 @@
 import 'webrtc-adapter';
 import * as React from 'react';
-import { IMediaStreamControlProps } from 'react-conf-webrtc';
+import { IMediaStreamControlRendererProps } from 'react-conf-webrtc';
 
-export interface ICustomMediaStreamControlStates {
-    isAudioEnabled: boolean;
-    isVideoEnabled: boolean
-}
-
-export default class CustomMediaStreamControl extends React.PureComponent<IMediaStreamControlProps, ICustomMediaStreamControlStates> {
-    constructor(props: IMediaStreamControlProps) {
+export default class CustomMediaStreamControl extends React.PureComponent<IMediaStreamControlRendererProps, {}> {
+    constructor(props: IMediaStreamControlRendererProps) {
         super(props);
-
-        const { getAudioEnabled, getVideoEnabled } = props;
-
-        this.state = {
-            isAudioEnabled: getAudioEnabled(),
-            isVideoEnabled: getVideoEnabled(),
-        }
 
         this.handleToggleAudio = this.handleToggleAudio.bind(this);
         this.handleToggleVideo = this.handleToggleVideo.bind(this);
     }
 
     render() {
-        const { isAudioEnabled, isVideoEnabled } = this.state;
+        const { audioEnabled, videoEnabled } = this.props;
 
-        const muteText = isAudioEnabled ? 'Mute Audio' : 'Unmute Audio';
-        const disableText = isVideoEnabled ? 'Disable Video' : 'Enable Video';
+        const muteText = audioEnabled ? 'Mute Audio' : 'Unmute Audio';
+        const disableText = videoEnabled ? 'Disable Video' : 'Enable Video';
 
         return (
             <div className='rcw-stream-controls'>
@@ -37,18 +25,12 @@ export default class CustomMediaStreamControl extends React.PureComponent<IMedia
     }
 
     private handleToggleAudio() {
-        const { setAudioEnabled } = this.props;
-        const { isAudioEnabled } = this.state;
-
-        this.setState({isAudioEnabled: !isAudioEnabled});
-        setAudioEnabled(!isAudioEnabled);
+        const { audioEnabled, setAudioEnabled } = this.props;
+        setAudioEnabled(!audioEnabled);
     }
 
     private handleToggleVideo() {
-        const { setVideoEnabled } = this.props;
-        const { isVideoEnabled } = this.state;
-
-        this.setState({isVideoEnabled: !isVideoEnabled});
-        setVideoEnabled(!isVideoEnabled);
+        const { videoEnabled, setVideoEnabled } = this.props;
+        setVideoEnabled(!videoEnabled);
     }
 }

--- a/docs/src/components/CustomMediaStreamControl.tsx
+++ b/docs/src/components/CustomMediaStreamControl.tsx
@@ -1,25 +1,21 @@
 import 'webrtc-adapter';
 import * as React from 'react';
-import { IMediaStreamControlHandle } from 'react-conf-webrtc';
-
-export interface ICustomMediaStreamControlProps {
-    handle: IMediaStreamControlHandle;
-}
+import { IMediaStreamControlProps } from 'react-conf-webrtc';
 
 export interface ICustomMediaStreamControlStates {
     isAudioEnabled: boolean;
     isVideoEnabled: boolean
 }
 
-export default class CustomMediaStreamControl extends React.PureComponent<ICustomMediaStreamControlProps, ICustomMediaStreamControlStates> {
-    constructor(props: ICustomMediaStreamControlProps) {
+export default class CustomMediaStreamControl extends React.PureComponent<IMediaStreamControlProps, ICustomMediaStreamControlStates> {
+    constructor(props: IMediaStreamControlProps) {
         super(props);
 
-        const { handle } = props;
+        const { getAudioEnabled, getVideoEnabled } = props;
 
         this.state = {
-            isAudioEnabled: handle.getAudioEnabled(),
-            isVideoEnabled: handle.getVideoEnabled(),
+            isAudioEnabled: getAudioEnabled(),
+            isVideoEnabled: getVideoEnabled(),
         }
 
         this.handleToggleAudio = this.handleToggleAudio.bind(this);
@@ -27,7 +23,6 @@ export default class CustomMediaStreamControl extends React.PureComponent<ICusto
     }
 
     render() {
-        const { handle } = this.props;
         const { isAudioEnabled, isVideoEnabled } = this.state;
 
         const muteText = isAudioEnabled ? 'Mute Audio' : 'Unmute Audio';
@@ -42,18 +37,18 @@ export default class CustomMediaStreamControl extends React.PureComponent<ICusto
     }
 
     private handleToggleAudio() {
-        const { handle } = this.props;
+        const { setAudioEnabled } = this.props;
         const { isAudioEnabled } = this.state;
 
         this.setState({isAudioEnabled: !isAudioEnabled});
-        handle.setAudioEnabled(!isAudioEnabled);
+        setAudioEnabled(!isAudioEnabled);
     }
 
     private handleToggleVideo() {
-        const { handle } = this.props;
+        const { setVideoEnabled } = this.props;
         const { isVideoEnabled } = this.state;
 
         this.setState({isVideoEnabled: !isVideoEnabled});
-        handle.setVideoEnabled(!isVideoEnabled);
+        setVideoEnabled(!isVideoEnabled);
     }
 }

--- a/docs/src/components/CustomMediaStreamControl.tsx
+++ b/docs/src/components/CustomMediaStreamControl.tsx
@@ -11,7 +11,7 @@ export interface ICustomMediaStreamControlStates {
     isVideoEnabled: boolean
 }
 
-export default class CustomMediaStreamControl extends React.Component<ICustomMediaStreamControlProps, ICustomMediaStreamControlStates> {
+export default class CustomMediaStreamControl extends React.PureComponent<ICustomMediaStreamControlProps, ICustomMediaStreamControlStates> {
     constructor(props: ICustomMediaStreamControlProps) {
         super(props);
 

--- a/docs/src/components/CustomMediaStreamControl.tsx
+++ b/docs/src/components/CustomMediaStreamControl.tsx
@@ -1,0 +1,59 @@
+import 'webrtc-adapter';
+import * as React from 'react';
+import { IMediaStreamControlHandle } from 'react-conf-webrtc';
+
+export interface ICustomMediaStreamControlProps {
+    handle: IMediaStreamControlHandle;
+}
+
+export interface ICustomMediaStreamControlStates {
+    isAudioEnabled: boolean;
+    isVideoEnabled: boolean
+}
+
+export default class CustomMediaStreamControl extends React.Component<ICustomMediaStreamControlProps, ICustomMediaStreamControlStates> {
+    constructor(props: ICustomMediaStreamControlProps) {
+        super(props);
+
+        const { handle } = props;
+
+        this.state = {
+            isAudioEnabled: handle.getAudioEnabled(),
+            isVideoEnabled: handle.getVideoEnabled(),
+        }
+
+        this.handleToggleAudio = this.handleToggleAudio.bind(this);
+        this.handleToggleVideo = this.handleToggleVideo.bind(this);
+    }
+
+    render() {
+        const { handle } = this.props;
+        const { isAudioEnabled, isVideoEnabled } = this.state;
+
+        const muteText = isAudioEnabled ? 'Mute Audio' : 'Unmute Audio';
+        const disableText = isVideoEnabled ? 'Disable Video' : 'Enable Video';
+
+        return (
+            <div className='rcw-stream-controls'>
+                <button className='rcw-stream-control-mute' onClick={this.handleToggleAudio}>{muteText}</button>
+                <button className='rcw-stream-control-disable' onClick={this.handleToggleVideo}>{disableText}</button>
+            </div>
+        )
+    }
+
+    private handleToggleAudio() {
+        const { handle } = this.props;
+        const { isAudioEnabled } = this.state;
+
+        this.setState({isAudioEnabled: !isAudioEnabled});
+        handle.setAudioEnabled(!isAudioEnabled);
+    }
+
+    private handleToggleVideo() {
+        const { handle } = this.props;
+        const { isVideoEnabled } = this.state;
+
+        this.setState({isVideoEnabled: !isVideoEnabled});
+        handle.setVideoEnabled(!isVideoEnabled);
+    }
+}

--- a/src/components/controls/MediaStreamControl.tsx
+++ b/src/components/controls/MediaStreamControl.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-export interface IMediaStreamControlHandle {
+export interface IMediaStreamControlProps {
     getAudioEnabled: () => boolean;
     setAudioEnabled: (enabled: boolean) => void;
     getVideoEnabled: () => boolean;
@@ -8,7 +8,7 @@ export interface IMediaStreamControlHandle {
 }
 
 export interface IMediaStreamControlRenderer {
-    (handle: IMediaStreamControlHandle): JSX.Element | null | false;
+    (props: IMediaStreamControlProps): JSX.Element | null | false;
 }
 
 export interface IMediaControlProps {

--- a/src/components/controls/MediaStreamControl.tsx
+++ b/src/components/controls/MediaStreamControl.tsx
@@ -50,19 +50,27 @@ export class MediaStreamControl extends React.PureComponent<IMediaControlProps, 
     }
 
     private getAudioEnabled(): boolean {
-        return this.props.stream.getAudioTracks()[0].enabled;
+        const track = this.props.stream.getAudioTracks()[0];
+        return track ? track.enabled : false;
     }
 
-    private setAudioEnabled(enabled: boolean) {
-        return this.props.stream.getAudioTracks()[0].enabled = enabled;
+    private setAudioEnabled(enabled: boolean): void {
+        const track = this.props.stream.getAudioTracks()[0];
+        if (track) {
+            track.enabled = enabled;
+        }
     }
 
     private getVideoEnabled(): boolean {
-        return this.props.stream.getVideoTracks()[0].enabled;
+        const track = this.props.stream.getVideoTracks()[0];
+        return track ? track.enabled : false;
     }
 
-    private setVideoEnabled(enabled: boolean) {
-        return this.props.stream.getVideoTracks()[0].enabled = enabled;
+    private setVideoEnabled(enabled: boolean): void {
+        const track = this.props.stream.getVideoTracks()[0];
+        if (track) {
+            track.enabled = enabled;
+        }
     }
 
     private onMuteButtonClick(event: any) {

--- a/src/components/controls/MediaStreamControl.tsx
+++ b/src/components/controls/MediaStreamControl.tsx
@@ -30,7 +30,6 @@ export class MediaStreamControl extends React.PureComponent<IMediaControlProps, 
         this.setVideoEnabled = this.setVideoEnabled.bind(this);
     }
 
-    // TODO(yunsi): Accept JSX.Element from props and let user customize the button style or button label.
     public render() {
         const { render } = this.props;
         if (render) {

--- a/src/components/controls/MediaStreamControl.tsx
+++ b/src/components/controls/MediaStreamControl.tsx
@@ -1,7 +1,19 @@
 import * as React from 'react';
 
+export interface IMediaStreamControlHandle {
+    getDisable: () => boolean;
+    setDisable: (disableState: boolean) => void;
+    getMute: () => boolean;
+    setMute: (muteState: boolean) => void;
+}
+
+export interface IMediaStreamControlRenderer {
+    (handle: IMediaStreamControlHandle): JSX.Element | null | false;
+}
+
 export interface IMediaControlProps {
     stream: MediaStream;
+    render? : IMediaStreamControlRenderer
 }
 
 export interface IMediaControlState { }
@@ -16,6 +28,15 @@ export class MediaStreamControl extends React.PureComponent<IMediaControlProps, 
 
     // TODO(yunsi): Accept JSX.Element from props and let user customize the button style or button label.
     public render() {
+        const { render } = this.props;
+        if (render) {
+            render({
+                getDisable: this.getDisable,
+                setDisable: this.setDisable,
+                getMute: this.getMute,
+                setMute: this.setMute,
+            });
+        }
         return (
             <div className='rcw-stream-controls'>
                 <button className='rcw-stream-control-mute' onClick={this.onMuteButtonClick}>Mute Audio</button>
@@ -24,14 +45,30 @@ export class MediaStreamControl extends React.PureComponent<IMediaControlProps, 
         )
     }
 
+    private getMute(): boolean {
+        return this.props.stream.getAudioTracks()[0].enabled;
+    }
+
+    private setMute(state: boolean) {
+        return this.props.stream.getAudioTracks()[0].enabled = state;
+    }
+
+    private getDisable(): boolean {
+        return this.props.stream.getVideoTracks()[0].enabled;
+    }
+
+    private setDisable(state: boolean) {
+        return this.props.stream.getVideoTracks()[0].enabled = state;
+    }
+
     private onMuteButtonClick(event: any) {
         if (!this.props.stream) {
             console.warn('No local stream');
             return;
         }
         // TODO(yunsi): Save the audioEnabled information for later use, E.g. send it to other clients as a remote stream status information.
-        const audioEnabled = this.props.stream.getAudioTracks()[0].enabled;
-        this.props.stream.getAudioTracks()[0].enabled = !audioEnabled;
+        const audioEnabled = this.getMute();
+        this.setMute(!audioEnabled);
     }
 
     private onDisableButtonClick(event: any) {
@@ -40,7 +77,7 @@ export class MediaStreamControl extends React.PureComponent<IMediaControlProps, 
             return;
         }
         // TODO(yunsi): Save the videoEnabled information for later use, E.g. send it to other clients as a remote stream status information.
-        const videoEnabled = this.props.stream.getVideoTracks()[0].enabled;
-        this.props.stream.getVideoTracks()[0].enabled = !videoEnabled;
+        const videoEnabled = this.getDisable();
+        this.setDisable(!videoEnabled);
     }
 }

--- a/src/components/controls/MediaStreamControl.tsx
+++ b/src/components/controls/MediaStreamControl.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 
 export interface IMediaStreamControlHandle {
-    getDisable: () => boolean;
-    setDisable: (disableState: boolean) => void;
-    getMute: () => boolean;
-    setMute: (muteState: boolean) => void;
+    getAudioEnabled: () => boolean;
+    setAudioEnabled: (enabled: boolean) => void;
+    getVideoEnabled: () => boolean;
+    setVideoEnabled: (enabled: boolean) => void;
 }
 
 export interface IMediaStreamControlRenderer {
@@ -24,17 +24,21 @@ export class MediaStreamControl extends React.PureComponent<IMediaControlProps, 
 
         this.onMuteButtonClick = this.onMuteButtonClick.bind(this);
         this.onDisableButtonClick = this.onDisableButtonClick.bind(this);
+        this.getAudioEnabled = this.getAudioEnabled.bind(this);
+        this.setAudioEnabled = this.setAudioEnabled.bind(this);
+        this.getVideoEnabled = this.getVideoEnabled.bind(this);
+        this.setVideoEnabled = this.setVideoEnabled.bind(this);
     }
 
     // TODO(yunsi): Accept JSX.Element from props and let user customize the button style or button label.
     public render() {
         const { render } = this.props;
         if (render) {
-            render({
-                getDisable: this.getDisable,
-                setDisable: this.setDisable,
-                getMute: this.getMute,
-                setMute: this.setMute,
+            return render({
+                getAudioEnabled: this.getAudioEnabled,
+                setAudioEnabled: this.setAudioEnabled,
+                getVideoEnabled: this.getVideoEnabled,
+                setVideoEnabled: this.setVideoEnabled,
             });
         }
         return (
@@ -45,20 +49,20 @@ export class MediaStreamControl extends React.PureComponent<IMediaControlProps, 
         )
     }
 
-    private getMute(): boolean {
+    private getAudioEnabled(): boolean {
         return this.props.stream.getAudioTracks()[0].enabled;
     }
 
-    private setMute(state: boolean) {
-        return this.props.stream.getAudioTracks()[0].enabled = state;
+    private setAudioEnabled(enabled: boolean) {
+        return this.props.stream.getAudioTracks()[0].enabled = enabled;
     }
 
-    private getDisable(): boolean {
+    private getVideoEnabled(): boolean {
         return this.props.stream.getVideoTracks()[0].enabled;
     }
 
-    private setDisable(state: boolean) {
-        return this.props.stream.getVideoTracks()[0].enabled = state;
+    private setVideoEnabled(enabled: boolean) {
+        return this.props.stream.getVideoTracks()[0].enabled = enabled;
     }
 
     private onMuteButtonClick(event: any) {
@@ -67,8 +71,8 @@ export class MediaStreamControl extends React.PureComponent<IMediaControlProps, 
             return;
         }
         // TODO(yunsi): Save the audioEnabled information for later use, E.g. send it to other clients as a remote stream status information.
-        const audioEnabled = this.getMute();
-        this.setMute(!audioEnabled);
+        const audioEnabled = this.getAudioEnabled();
+        this.setAudioEnabled(!audioEnabled);
     }
 
     private onDisableButtonClick(event: any) {
@@ -77,7 +81,7 @@ export class MediaStreamControl extends React.PureComponent<IMediaControlProps, 
             return;
         }
         // TODO(yunsi): Save the videoEnabled information for later use, E.g. send it to other clients as a remote stream status information.
-        const videoEnabled = this.getDisable();
-        this.setDisable(!videoEnabled);
+        const videoEnabled = this.getVideoEnabled();
+        this.setVideoEnabled(!videoEnabled);
     }
 }


### PR DESCRIPTION
fix #72 

I changed some methods name:

```
get/set mute -> get/set AudioEnabled
get/set disabled -> get/set VideoEnabled
```

I wrote the reason in commit "Term change" 's message, not sure is it OK. Maybe we can talk about this.
