### PR TITLE
Provide the way of injecting adapter and connection to customize message

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -26,7 +26,7 @@
     "html-webpack-plugin": "2.29.0",
     "node-sass": "4.5.3",
     "react": "15.6.1",
-    "react-conf-webrtc": "0.0.11",
+    "react-conf-webrtc": "0.0.12",
     "react-dom": "15.6.1",
     "rimraf": "2.6.1",
     "sass-loader": "6.0.6",

--- a/demo/src/components/App.tsx
+++ b/demo/src/components/App.tsx
@@ -5,7 +5,7 @@ import { env } from '../config/config';
 
 import {
     Conference,
-    Connect,
+    SpreedConnect,
     ConferenceStream,
     Stream,
     IMediaStreamControlRendererProps,
@@ -123,7 +123,7 @@ export class App extends React.Component<{}, {}> {
 // TODO(andrew): Figure out how to make this work with env
 function connect() {
     const webRTCUrl = env.SPREED_URL ? env.SPREED_URL : location.hostname + ":8443";
-    const conn = Connect('wss://' + webRTCUrl + '/ws');
+    const conn = SpreedConnect('wss://' + webRTCUrl + '/ws');
     conn.onconnmessage = (msg, done) => {
         console.log('Intercepted SpreedResponse message with type: %s', msg.Data.Type);
         done()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-conf-webrtc",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/Spreed/Connect.ts
+++ b/src/Spreed/Connect.ts
@@ -1,11 +1,11 @@
-import { ConferenceConnection, ConferenceConnectionSubscriber } from '../data/ConferenceConnection';
+import { ConferenceConnection } from '../data/ConferenceConnection';
 import { IConfIncomingMessage, IConfOutgoingMessage } from '../data/ConferenceMessage';
 import { SpreedConnection } from './SpreedConnection';
 import { SpreedAdapter } from './SpreedAdapter';
 import { SpreedResponse } from '../Spreed';
 
-export function Connect(url: string): Connection {
-    return new Connection(url);
+export function SpreedConnect(url: string): SpreedConferenceConnection {
+    return new SpreedConferenceConnection(url);
 }
 
 // NOTE(andrews): Connection class is responsible for controlling the communication
@@ -13,48 +13,9 @@ export function Connect(url: string): Connection {
 // for subscribers to hook into the SpreedConnection event stream. This means
 // that anytime the SpreedServer sends a message to the SpreedConnection, you
 // can be notified.
-export class Connection implements ConferenceConnection {
-    private conn: SpreedConnection;
-    private adapter: SpreedAdapter;
-    private onConnMessageHandler?: SpreedConnectionMessageHandler;
-
+export class SpreedConferenceConnection extends ConferenceConnection {
     constructor(url: string) {
-        this.conn = new SpreedConnection(url);
-        this.adapter = new SpreedAdapter();
-        this.conn.onmessage = (msg) => {
-            if (this.onConnMessageHandler) {
-                this.onConnMessageHandler(msg, () => {
-                    this.adapter.handleSpreedMessage(msg);
-                })
-                return
-            }
-            this.adapter.handleSpreedMessage(msg);
-        }
-        this.adapter.onSpreedMessage = (msg) => {
-            this.conn.send(msg);
-        }
-    }
-
-    // NOTE(andrews): Use this API if you want to subscribe to the incoming event
-    // stream from the SpreedConnection class. Note that done() must be called
-    // by your handler if you want the message to continue through to the
-    // connection.
-    set onconnmessage(handler: SpreedConnectionMessageHandler) {
-        this.onConnMessageHandler = handler;
-    }
-
-    public subscribe(handler: ConferenceConnectionSubscriber) {
-        this.adapter.onConferenceMessage = (msg) => {
-            handler(msg);
-        }
-    }
-
-    public publish(msg: IConfOutgoingMessage) {
-        this.adapter.handleConferenceMessage(msg);
-    }
-
-    public close() {
-        this.conn.close()
+        super(url, new SpreedConnection(), new SpreedAdapter())
     }
 }
 

--- a/src/Spreed/SpreedAdapter.ts
+++ b/src/Spreed/SpreedAdapter.ts
@@ -3,114 +3,34 @@ import { SpreedResponse } from './SpreedResponse';
 import {
     IConfOutgoingMessage,
     IConfIncomingMessage,
-} from '../data/ConferenceMessage'
+    IMessageAdapter,
+} from '../data'
 import { TranslateSpreedMessage } from './TranslateSpreedMessage';
 import { TranslateConferenceMessage } from './TranslateConferenceMessage';
 
 // NOTE(andrews): SpreedAdapter is responsible for turning SpreedMessages into Conference messages
-// and vice-versa. If either receiving end has no receiver, it will queue the messages.
-export class SpreedAdapter {
-    private conferenceMessageHandler?: AdapterHandlerConferenceMessage;
-    private spreedMessageHandler?: AdapterHandlerSpreedMessage;
-    private conferenceMessages: IConfIncomingMessage[] = [];
-    private spreedMessages: SpreedRequest[] = []
-
+// and vice-versa.
+export class SpreedAdapter implements IMessageAdapter {
     // NOTE(andrews): handleSpreedMessage should be called whenever you want to translate a message from spreed -> conference.
     // Not all message types will be handled
-    public handleSpreedMessage(message: SpreedResponse): void {
+    public translateIncomingMessage(message: SpreedResponse): IConfIncomingMessage[] | IConfIncomingMessage | undefined {
         const msg = TranslateSpreedMessage(message);
         if (!msg) {
-            console.log('handleSpreedMessage(): No translation was found for SpreedResponse type: %s', message.Data.Type);
-            return;
-        }
-        if (msg instanceof Array) {
-            msg.forEach(m => {
-                this.sendConferenceMessage(m);
-            });
+            console.log('translateIncomingMessage(): No translation was found for SpreedResponse type: %s', message.Data.Type);
             return
         }
-        this.sendConferenceMessage(msg);
+
+        return msg;
     }
 
     // NOTE(andrews): handleConferenceMessage should be called whenever you want to translate a message from conference -> spreed.
-    public handleConferenceMessage(message: IConfOutgoingMessage): void {
+    public translateOutgoingMessage(message: IConfOutgoingMessage): any {
         const msg = TranslateConferenceMessage(message);
         if (!msg) {
-            console.log('handleConferenceMessage(): No translation was found for IConfOutgoingMessage type: %s', message.type);
+            console.log('translateOutgoingMessage(): No translation was found for IConfOutgoingMessage type: %s', message.type);
             return
         }
-        this.sendSpreedMessage(msg);
+
+        return msg;
     }
-
-    // NOTE(andrews): onConferenceMessage is used to notify your handler when a conference message is available.
-    set onConferenceMessage(handler: AdapterHandlerConferenceMessage) {
-        this.conferenceMessageHandler = handler;
-        this.processConferenceMessages();
-    }
-
-    // NOTE(andrews): onSpreedMessage is used to notify your handler when a spreed message is available.
-    set onSpreedMessage(handler: AdapterHandlerSpreedMessage) {
-        this.spreedMessageHandler = handler;
-        this.processSpreedMessages();
-    }
-
-    // NOTE(andrews): processConferenceMessages will process all of the queued conference messages.
-    // If no handler is defined this function will return before attempting to process the queue.
-    private processConferenceMessages() {
-        if (!this.conferenceMessageHandler) {
-            return;
-        }
-        while (this.conferenceMessages.length > 0) {
-            const message = this.conferenceMessages.shift();
-            if (!message) {
-                console.warn('processConferenceMessages(): undefined message in queue');
-                continue
-            }
-            this.conferenceMessageHandler(message);
-        }
-    }
-
-    // NOTE(andrews): processSpreedMessages will process all of the queued spreed messages.
-    // If no handler is defined this function will return before attempting to process the queue.
-    private processSpreedMessages() {
-        if (!this.spreedMessageHandler) {
-            return;
-        }
-        while (this.spreedMessages.length > 0) {
-            const message = this.spreedMessages.shift();
-            if (!message) {
-                console.warn('processSpreedMessages(): undefined message in queue');
-                continue
-            }
-            this.spreedMessageHandler(message);
-        }
-    }
-
-    // NOTE(andrews): sendConferenceMessage is used to send a conference message to the handler. If no handler
-    // is defined the message will be queued.
-    private sendConferenceMessage(message: IConfIncomingMessage) {
-        if (this.conferenceMessageHandler) {
-            this.conferenceMessageHandler(message);
-            return
-        }
-        this.conferenceMessages.push(message);
-    }
-
-    // NOTE(andrews): sendSpreedMessage is used to send a conference message to the handler. If no handler
-    // is defined the message will be queued.
-    private sendSpreedMessage(message: SpreedRequest) {
-        if (this.spreedMessageHandler) {
-            this.spreedMessageHandler(message);
-            return
-        }
-        this.spreedMessages.push(message);
-    }
-}
-
-export interface AdapterHandlerConferenceMessage {
-    (message: IConfIncomingMessage): void;
-}
-
-export interface AdapterHandlerSpreedMessage {
-    (message: SpreedRequest): void;
 }

--- a/src/Spreed/SpreedConnection.ts
+++ b/src/Spreed/SpreedConnection.ts
@@ -1,3 +1,4 @@
+import { IConnection } from '../data/';
 import { SpreedResponse } from './SpreedResponse';
 import { SpreedRequest } from './SpreedRequest';
 
@@ -5,7 +6,7 @@ import { SpreedRequest } from './SpreedRequest';
 // It will queue any responses (messages from the server) and requests (messages from the client)
 // if no receiver is ready. Messages from the server are processed once an `onmessage` handler is assigned.
 // Likewise, messages from the client are only processed once the WebSocket connection is open.
-export class SpreedConnection {
+export class SpreedConnection implements IConnection {
     private conn: WebSocket;
     private onCloseHandler: SpreedConnCloseHandler;
     private onErrorHandler: SpreedConnErrorHandler;
@@ -15,7 +16,7 @@ export class SpreedConnection {
     // queue of client -> server messages
     private requests: SpreedRequest[] = [];
 
-    constructor(url: string) {
+    public connect(url: string) {
         this.conn = new WebSocket(url);
         this.conn.onmessage = this.onConnMessage.bind(this);
         this.conn.onclose = this.onConnClose.bind(this);

--- a/src/data/ConferenceConnection.ts
+++ b/src/data/ConferenceConnection.ts
@@ -3,12 +3,124 @@ import { IConfOutgoingMessage, IConfIncomingMessage } from './ConferenceMessage'
 // NOTE(andrews): ConferenceConnection is an interface that your connection object
 // must satisfy. The Conference component will depend on this interface when it calls
 // the createConnection API.
-export interface ConferenceConnection {
+export interface IConferenceConnection {
     subscribe: (subscriber: ConferenceConnectionSubscriber) => void;
     publish: (message: IConfOutgoingMessage) => void;
     close: () => void;
 }
 
+export interface IConnection {
+    connect: (url: string) => void;
+    onmessage: (message: any) => void;
+    send: (message: any) => void;
+    close: () => void;
+}
+
+export interface IMessageAdapter {
+    translateIncomingMessage: (message: any) => IConfIncomingMessage[] | IConfIncomingMessage | undefined;
+    translateOutgoingMessage: (message: IConfOutgoingMessage) => any;
+}
+
 export interface ConferenceConnectionSubscriber {
     (message: IConfIncomingMessage): void;
+}
+
+export interface MessageHandler {
+    (message: any, done: () => void): void
+}
+
+// ConferenceConnection Connection class is responsible for controlling the communication
+// between the IConnection and IMessageAdapter instances. It exposes an API
+// for subscribers to hook into the IConnection event stream. This means
+// that anytime the server sends a message to the IConnection, you
+// can be notified.
+export class ConferenceConnection implements IConferenceConnection {
+    private conn: IConnection;
+    private adapter: IMessageAdapter;
+    private conferenceMessageHandler?: ConferenceConnectionSubscriber;
+    private onConnMessageHandler?: MessageHandler;
+    private incomingMessages: IConfIncomingMessage[] = [];
+
+    constructor(url: string, conn: IConnection, adapter: IMessageAdapter) {
+        this.conn = conn;
+        this.conn.connect(url);
+        this.adapter = adapter;
+
+        this.conn.onmessage = (msg) => {
+            if (this.onConnMessageHandler) {
+                this.onConnMessageHandler(msg, () => {
+                    this.handleIncomingMessage(msg);
+                })
+                return
+            }
+            this.handleIncomingMessage(msg);
+        }
+    }
+
+    public subscribe(handler: ConferenceConnectionSubscriber) {
+        this.conferenceMessageHandler = handler;
+        this.processIncomingMessages();
+    }
+
+    public publish(msg: IConfOutgoingMessage) {
+        const outgoingMessage = this.adapter.translateOutgoingMessage(msg);
+        if (!outgoingMessage) {
+            console.log('handleConferenceMessage(): No translation was found for IConfOutgoingMessage type: %s', msg.type);
+            return;
+        }
+        this.conn.send(outgoingMessage);
+    }
+
+    // NOTE(andrews): Use this API if you want to subscribe to the incoming event
+    // stream from the SpreedConnection class. Note that done() must be called
+    // by your handler if you want the message to continue through to the
+    // connection.
+    set onconnmessage(handler: MessageHandler) {
+        this.onConnMessageHandler = handler;
+    }
+
+    private handleIncomingMessage(msg: any) {
+        const incomingMessage = this.adapter.translateIncomingMessage(msg);
+
+        if (!incomingMessage) {
+            return;
+        }
+
+        if (incomingMessage instanceof Array) {
+            incomingMessage.forEach(m => {
+                this.notifyConferenceMessage(m);
+            });
+        }
+        else {
+            this.notifyConferenceMessage(incomingMessage);
+        }
+    }
+
+    private notifyConferenceMessage(msg: IConfIncomingMessage) {
+        if (this.conferenceMessageHandler) {
+            this.conferenceMessageHandler(msg);
+            return
+        }
+        this.incomingMessages.push(msg);
+    }
+
+    // NOTE(andrews): processIncomingMessages will process all of the queued conference messages.
+    // If no handler is defined this function will return before attempting to process the queue.
+    private processIncomingMessages() {
+        if (!this.conferenceMessageHandler) {
+            return;
+        }
+        while (this.incomingMessages.length > 0) {
+            const message = this.incomingMessages.shift();
+            if (!message) {
+                console.warn('processIncomingMessages(): undefined message in queue');
+                continue
+            }
+            this.conferenceMessageHandler(message);
+        }
+    }
+
+    public close() {
+        this.conn.close()
+    }
 }

--- a/src/data/ConferenceConnection.ts
+++ b/src/data/ConferenceConnection.ts
@@ -29,7 +29,7 @@ export interface MessageHandler {
     (message: any, done: () => void): void
 }
 
-// ConferenceConnection Connection class is responsible for controlling the communication
+// ConferenceConnection class is responsible for controlling the communication
 // between the IConnection and IMessageAdapter instances. It exposes an API
 // for subscribers to hook into the IConnection event stream. This means
 // that anytime the server sends a message to the IConnection, you


### PR DESCRIPTION
1. ConferenceConnection controls the communication between IConnection and IMessageAdapter. It uses IConnection and IMessageAdapter to send and receive messages and case messages to ConferenceMessage
2. SpreedConference can have its own IConnection and IMessageAdapter instance.
3. Move message queue logic into ConferenceConnection from SpreedAdapter, which is common for all the logic, not only spreed.

Next step:
Message translator can be moved into SpreedAdapter.

The way provides the flexibility to inject 3rd party adapter to connect customized spreed note.